### PR TITLE
Error detection: Get path with error

### DIFF
--- a/deno/tree.ts
+++ b/deno/tree.ts
@@ -15,7 +15,7 @@ export type DependencyTree = Array<{
 export interface IDependencyTree {
   tree: DependencyTree;
   circular: boolean;
-  errors: any[]
+  errors: Array<[string, any]>;
   count: number;
   iterator: IterableIterator<string>;
 }
@@ -34,7 +34,7 @@ export async function dependencyTree(
 
   const { fullTree } = options;
 
-  const errors: any[] = []
+  const errors: Array<[string, any]> = [];
   let circular = false;
   let count = 0;
 
@@ -87,7 +87,7 @@ export async function dependencyTree(
           imports: subTree.value,
         });
       } else {
-        errors.push(subTree.reason)
+        errors.push([dependencies[i], subTree.reason]);
         depTree.push({
           path: dependencies[i],
           imports: [{

--- a/wasm/web.js
+++ b/wasm/web.js
@@ -10,7 +10,7 @@ await init();
  * @returns {Promise<{
     tree: DependencyTree;
     circular: boolean;
-    errors: any[];
+    errors: [string, any][];
     count: number;
     iterator: IterableIterator<string>;
   }>}
@@ -70,7 +70,7 @@ export async function dependencyTree(path, options = { fullTree: false }) {
           imports: subTree.value,
         });
       } else {
-        errors.push(subTree.reason)
+        errors.push([dependencies[i], subTree.reason])
         depTree.push({
           path: dependencies[i],
           imports: [{


### PR DESCRIPTION
Again a small change, I didn't think about that before 😕

Previously when an error was detected you had no clue where the error was in the tree. Now you get the file path with the error.